### PR TITLE
Specified YAML Loader to BaseLoader.

### DIFF
--- a/pyannote/database/custom.py
+++ b/pyannote/database/custom.py
@@ -222,7 +222,7 @@ def add_custom_protocols(config_yml=None):
 
     try:
         with open(config_yml, 'r') as fp:
-            config = yaml.load(fp)
+            config = yaml.load(fp, Loader=yaml.BaseLoader)
 
     except FileNotFoundError:
         config = dict()

--- a/pyannote/database/util.py
+++ b/pyannote/database/util.py
@@ -437,7 +437,7 @@ def load_rttm(file_rttm):
     names = ['NA1', 'uri', 'NA2', 'start', 'duration',
              'NA3', 'NA4', 'speaker', 'NA5', 'NA6']
     dtype = {'uri': str, 'start': float, 'duration': float, 'speaker': str}
-    data = pd.read_table(file_rttm, names=names, dtype=dtype,
+    data = pd.read_csv(file_rttm, sep='\t', names=names, dtype=dtype,
                          delim_whitespace=True)
 
     annotations = dict()
@@ -525,7 +525,7 @@ def load_mdtm(file_mdtm):
 
     names = ['uri', 'NA1', 'start', 'duration', 'NA2', 'NA3', 'NA4', 'speaker']
     dtype = {'uri': str, 'start': float, 'duration': float, 'speaker': str}
-    data = pd.read_table(file_mdtm, names=names, dtype=dtype,
+    data = pd.read_csv(file_mdtm, sep='\t', names=names, dtype=dtype,
                          delim_whitespace=True)
 
     annotations = dict()
@@ -555,7 +555,7 @@ def load_uem(file_uem):
 
     names = ['uri', 'NA1', 'start', 'end']
     dtype = {'uri': str, 'start': float, 'end': float}
-    data = pd.read_table(file_uem, names=names, dtype=dtype,
+    data = pd.read_csv(file_uem, sep='\t', names=names, dtype=dtype,
                          delim_whitespace=True)
 
     timelines = dict()

--- a/pyannote/database/util.py
+++ b/pyannote/database/util.py
@@ -437,7 +437,7 @@ def load_rttm(file_rttm):
     names = ['NA1', 'uri', 'NA2', 'start', 'duration',
              'NA3', 'NA4', 'speaker', 'NA5', 'NA6']
     dtype = {'uri': str, 'start': float, 'duration': float, 'speaker': str}
-    data = pd.read_csv(file_rttm, sep='\t', names=names, dtype=dtype,
+    data = pd.read_csv(file_rttm, names=names, dtype=dtype,
                          delim_whitespace=True)
 
     annotations = dict()
@@ -525,7 +525,7 @@ def load_mdtm(file_mdtm):
 
     names = ['uri', 'NA1', 'start', 'duration', 'NA2', 'NA3', 'NA4', 'speaker']
     dtype = {'uri': str, 'start': float, 'duration': float, 'speaker': str}
-    data = pd.read_csv(file_mdtm, sep='\t', names=names, dtype=dtype,
+    data = pd.read_csv(file_mdtm, names=names, dtype=dtype,
                          delim_whitespace=True)
 
     annotations = dict()
@@ -555,7 +555,7 @@ def load_uem(file_uem):
 
     names = ['uri', 'NA1', 'start', 'end']
     dtype = {'uri': str, 'start': float, 'end': float}
-    data = pd.read_csv(file_uem, sep='\t', names=names, dtype=dtype,
+    data = pd.read_csv(file_uem, names=names, dtype=dtype,
                          delim_whitespace=True)
 
     timelines = dict()

--- a/pyannote/database/util.py
+++ b/pyannote/database/util.py
@@ -89,7 +89,7 @@ class FileFinder(object):
 
         try:
             with open(config_yml, 'r') as fp:
-                config = yaml.load(fp)
+                config = yaml.load(fp, Loader=yaml.BaseLoader)
 
         except FileNotFoundError:
             config = dict()


### PR DESCRIPTION
Due to security issues with the `yaml.load` function, a `Loader` must be specified.
I chose `yaml.BaseLoader` which only parses basic python objects such as dictionnaries, lists and strings. `config.yml` files in pyannote does not need more but it could be replaced easily by another Loader if needed.
See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation for more details.