### PR TITLE
Specified YAML Loader to BaseLoader in yaml.load function.

### DIFF
--- a/pyannote/database/custom.py
+++ b/pyannote/database/custom.py
@@ -222,7 +222,7 @@ def add_custom_protocols(config_yml=None):
 
     try:
         with open(config_yml, 'r') as fp:
-            config = yaml.load(fp)
+            config = yaml.load(fp, Loader=yaml.BaseLoader)
 
     except FileNotFoundError:
         config = dict()

--- a/pyannote/database/util.py
+++ b/pyannote/database/util.py
@@ -89,7 +89,7 @@ class FileFinder(object):
 
         try:
             with open(config_yml, 'r') as fp:
-                config = yaml.load(fp)
+                config = yaml.load(fp, Loader=yaml.BaseLoader)
 
         except FileNotFoundError:
             config = dict()


### PR DESCRIPTION
Due to security issues with the yaml.load function, a Loader must be specified.
I chose yaml.BaseLoader which only parses basic python objects such as dictionnaries, lists and strings. config.yml files in pyannote does not need more but it could be replaced easily by another Loader if needed.
See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation for more details.