### PR TITLE
Replaced pandas.read_table (deprecated) with pandas.read_csv.

### DIFF
--- a/pyannote/database/util.py
+++ b/pyannote/database/util.py
@@ -437,8 +437,8 @@ def load_rttm(file_rttm):
     names = ['NA1', 'uri', 'NA2', 'start', 'duration',
              'NA3', 'NA4', 'speaker', 'NA5', 'NA6']
     dtype = {'uri': str, 'start': float, 'duration': float, 'speaker': str}
-    data = pd.read_table(file_rttm, names=names, dtype=dtype,
-                         delim_whitespace=True)
+    data = pd.read_csv(file_rttm, names=names, dtype=dtype,
+                       delim_whitespace=True)
 
     annotations = dict()
     for uri, turns in data.groupby('uri'):
@@ -525,8 +525,8 @@ def load_mdtm(file_mdtm):
 
     names = ['uri', 'NA1', 'start', 'duration', 'NA2', 'NA3', 'NA4', 'speaker']
     dtype = {'uri': str, 'start': float, 'duration': float, 'speaker': str}
-    data = pd.read_table(file_mdtm, names=names, dtype=dtype,
-                         delim_whitespace=True)
+    data = pd.read_csv(file_mdtm, names=names, dtype=dtype,
+                       delim_whitespace=True)
 
     annotations = dict()
     for uri, turns in data.groupby('uri'):
@@ -555,8 +555,8 @@ def load_uem(file_uem):
 
     names = ['uri', 'NA1', 'start', 'end']
     dtype = {'uri': str, 'start': float, 'end': float}
-    data = pd.read_table(file_uem, names=names, dtype=dtype,
-                         delim_whitespace=True)
+    data = pd.read_csv(file_uem, names=names, dtype=dtype,
+                       delim_whitespace=True)
 
     timelines = dict()
     for uri, parts in data.groupby('uri'):


### PR DESCRIPTION
The `pandas.read_table` function is deprecated (see https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_table.html) and can be replaced by `pandas.read_csv`. The `delim_whitespace` should be enough to correctly parse rttm files.