### PR TITLE
Changed YAML Loader to yaml.SafeLoader.

### DIFF
--- a/pyannote/database/custom.py
+++ b/pyannote/database/custom.py
@@ -222,7 +222,7 @@ def add_custom_protocols(config_yml=None):
 
     try:
         with open(config_yml, 'r') as fp:
-            config = yaml.load(fp)
+            config = yaml.load(fp, Loader=yaml.SafeLoader)
 
     except FileNotFoundError:
         config = dict()

--- a/pyannote/database/util.py
+++ b/pyannote/database/util.py
@@ -89,7 +89,7 @@ class FileFinder(object):
 
         try:
             with open(config_yml, 'r') as fp:
-                config = yaml.load(fp)
+                config = yaml.load(fp, Loader=yaml.SafeLoader)
 
         except FileNotFoundError:
             config = dict()


### PR DESCRIPTION
Due to security issues when using the `yaml.load` function, the attribute `Loader` has to be set to a secure loader. Several are available and we chose `yaml.SafeLoader`.
For more information, see https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation.