### PR TITLE
typo in ~/.pyannote/database.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ TODO
 # ~/.pyannote/database.yml
 Protocols:
   DatabaseName:
-    SpeakerDiarization
+    SpeakerDiarization:
       ProtocolName:
         train:
             annotation: path/to/annotation/train/file.rttm


### PR DESCRIPTION
added ":"
Remark: it's unclear what should be in path/to/list_of_uris/train/file.lst
From what I understood one shouldn't provide annotation and uris at the same time