### PR TITLE
 fix (again): ensure database name is 'str', see also #31 

### DIFF
--- a/pyannote/database/util.py
+++ b/pyannote/database/util.py
@@ -89,7 +89,7 @@ class FileFinder:
             config = yaml.load(fp, Loader=yaml.SafeLoader)
 
         self.config_: Dict[DatabaseName, Union[PathTemplate, List[PathTemplate]]] = \
-            config.get('Databases', dict())
+            {str(database): path for database, path in config.get('Databases', dict()).items()}
 
     def __call__(self, current_file: 'ProtocolFile') -> Path:
         """Look for current file

--- a/pyannote/database/util.py
+++ b/pyannote/database/util.py
@@ -111,7 +111,7 @@ class FileFinder:
         """
 
         uri = current_file["uri"]
-        database = current_file["database"]
+        database = str(current_file["database"])
 
         # read
         path_templates = self.config_[database]

--- a/pyannote/database/util.py
+++ b/pyannote/database/util.py
@@ -111,7 +111,7 @@ class FileFinder:
         """
 
         uri = current_file["uri"]
-        database = str(current_file["database"])
+        database = current_file["database"]
 
         # read
         path_templates = self.config_[database]


### PR DESCRIPTION
You must think: what happened now ?

- database name is converted to `str` here https://github.com/pyannote/pyannote-database/blob/develop/pyannote/database/custom.py#L263
- however it was still an `int` there https://github.com/pyannote/pyannote-database/blob/develop/pyannote/database/util.py#L117 -> `KeyError`