### PR TITLE
feat: add support for custom SpeakerVerification protocols

### DIFF
--- a/tests/database.yml
+++ b/tests/database.yml
@@ -1,0 +1,38 @@
+Databases:
+   VoxCeleb:
+      - /path/to/voxceleb/voxceleb1/dev/wav/{uri}.wav
+      - /path/to/voxceleb/voxceleb1/test/wav/{uri}.wav
+      - /path/to/voxceleb/voxceleb2/dev/aac/{uri}.wav
+      - /path/to/voxceleb/voxceleb2/test/aac/{uri}.wav
+   MUSAN: /path/to/musan/{uri}.wav
+   AMI: /path/to/amicorpus/*/audio/{uri}.wav
+   MyVoxCeleb:
+      - /path/to/voxceleb/voxceleb1/dev/wav/{uri}.wav
+      - /path/to/voxceleb/voxceleb1/test/wav/{uri}.wav
+      - /path/to/voxceleb/voxceleb2/dev/aac/{uri}.wav
+      - /path/to/voxceleb/voxceleb2/test/aac/{uri}.wav
+
+Protocols:
+   AMI:
+      SpeakerDiarization:
+         MixHeadset:
+           train:
+              annotation: /path/to/AMI/MixHeadset.train.rttm
+              annotated: /path/to/AMI/MixHeadset.train.uem
+           development:
+              annotation: /path/to/AMI/MixHeadset.development.rttm
+              annotated: /path/to/AMI/MixHeadset.development.uem
+           test:
+              annotation: /path/to/AMI/MixHeadset.test.rttm
+              annotated: /path/to/AMI/MixHeadset.test.uem
+   MyVoxCeleb:
+      SpeakerVerification:
+         VoxCeleb2:
+           train:
+              annotation: /path/to/voxceleb/myvoxceleb/VoxCeleb2.train.rttm
+            #   annotated: /path/to/voxceleb/myvoxceleb/VoxCeleb2.train.uem
+           test_trial:
+              # annotation: /path/to/voxceleb/myvoxceleb/VoxCeleb2.test.rttm
+              # annotated: /path/to/voxceleb/myvoxceleb/VoxCeleb2.test.uem
+              duration: /path/to/voxceleb/myvoxceleb/vox1_all_duration.txt.gz # should contain all the file present in the trial
+              trial: /path/to/voxceleb/myvoxceleb/VoxCeleb2.test.trial 

--- a/tests/show-db.py
+++ b/tests/show-db.py
@@ -1,0 +1,14 @@
+# Will show all the databeses and their methods
+
+from pyannote.database import get_databases, get_database, get_protocol
+for db_name in get_databases():
+	db = get_database(db_name)
+	tasks_names = db.get_tasks()
+	for task in tasks_names:
+		protocols = db.get_protocols(task=task)
+		for protocol_name in protocols:
+			tmp = '{}.{}.{}'.format(db_name, task, protocol_name)
+			protocol = get_protocol(tmp)
+			print('#'*10)
+			print(tmp)
+			print([i for i in dir(protocol) if i in ['dev_iter', 'dev_try_iter', 'development', 'development_trial', 'test', 'test_trial', 'train', 'train_trial', 'trn_iter', 'trn_try_iter', 'tst_iter', 'tst_try_iter', 'xxx_try_iter', 'xxx_iter']])

--- a/tests/test-custom-db.py
+++ b/tests/test-custom-db.py
@@ -1,0 +1,28 @@
+from pyannote.database import  get_protocol
+
+protocol = get_protocol('MyVoxCeleb.SpeakerVerification.VoxCeleb2')
+
+# print('[Loading test set]')
+# for i, c_file in enumerate(protocol.test()):
+#     print(c_file['uri'])
+#     if i >= 10: break
+
+# print(['Loading train set'])
+# for i, c_file in enumerate(protocol.train()):
+#     print(c_file)
+#     if i >= 10: break
+
+print('[tst_try_iter]')
+for i, c_trial in enumerate(protocol.tst_try_iter()):
+    print(c_trial)
+    if i >= 10: break
+
+print('[test_trial]')
+for i, c_trial in enumerate(protocol.test_trial()):
+    print(c_trial)
+    if i >= 10: break
+
+print("[train_trials, shouldn't do anything]")
+for i, c_trial in enumerate(protocol.train_trial()):
+    pritn(c_trial['file1'])
+    if i >= 10: break


### PR DESCRIPTION
I modified the custom.py for it to support the creation of speaker verification protocols on the fly.

I added two keys in the configuration file ```database.yml``` : 
* duration for a duration file, those files seems common in these tasks.
* trial for a trial file, needed for spk verif.

I tested the validation and the training of a speaker embedding model with Voxceleb2 as the custom dataset I named myVoxCeleb and it worked.