### PR TITLE
feat: add support for basic "Segmentation" protocols

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -8,9 +8,10 @@ Version 5.0 (2023-xx-xx)
   - feat(registry): add pyannote.database.registry to load multiple YAML configuration file
   - BREAKING: turn pyannote.database.get_{database|protocol|protocols} function into registry methods
   - BREAKING: remove support for database plugins (via "pyannote.database.database" entrypoint)
+  - feat(protocol): add generic segmentation protocol with "classes" metadata
+  - feat(protocol): add support for label "scope" in speaker diarization protocols
   - feat(protocol): make ProtocolFile pickable
-  - feat(loader): add LAB file support
-  - feat(loader): add STM file support
+  - feat(loader): add support for LAB and STM files
   - feat(loader): add option to filter RTTM lines by "type"
   - fix(cli): fix corner case when annotation key is missing
 

--- a/pyannote/database/custom.py
+++ b/pyannote/database/custom.py
@@ -436,12 +436,22 @@ def create_protocol(
         protocol_entries = {"files": protocol_entries}
 
     metadata = dict()
-    # check whether base_class is a subclass of SegmentationProtocol
+
     if issubclass(base_class, SegmentationProtocol):
-        metadata["classes"] = protocol_entries.pop("classes", None)
+        if "classes" in protocol_entries:
+            metadata["classes"] = protocol_entries.pop("classes")
 
     if issubclass(base_class, SpeakerDiarizationProtocol):
-        metadata["scope"] = protocol_entries.pop("scope", "file")
+        if "scope" in protocol_entries:
+            scope = protocol_entries.pop("scope")
+        else:
+            scope = "file"
+            msg = (
+                f"'{database}.{task}.{protocol}' found in {database_yml} does not define "
+                f"the 'scope' of speaker labels (file, database, or global). Setting it to 'file'."
+            )   
+            print(msg)
+        metadata["scope"] = scope
 
     methods = dict()
     for subset, subset_entries in protocol_entries.items():

--- a/pyannote/database/custom.py
+++ b/pyannote/database/custom.py
@@ -54,7 +54,9 @@ import warnings
 from typing import Text, Dict, Callable, Any, Union
 import functools
 
-from .protocol.protocol import Subset
+from .protocol.protocol import Subset, Scope
+from .protocol.segmentation import SegmentationProtocol
+from .protocol.speaker_diarization import SpeakerDiarizationProtocol
 
 import pkg_resources
 
@@ -265,6 +267,7 @@ def subset_iter(
     subset: Subset = None,
     entries: Dict = None,
     database_yml: Path = None,
+    **metadata,
 ):
     """
 
@@ -282,6 +285,9 @@ def subset_iter(
         Subset entries.
     database_yml : `Path`
         Path to the 'database.yml' file
+    metadata : dict
+        Additional metadata to be added to each ProtocolFile (such
+        as "scope" or "classes")
     """
 
     if "uri" in entries:
@@ -305,9 +311,8 @@ def subset_iter(
 
     for uri in uris:
         yield ProtocolFile(
-            {"uri": uri, "database": database, "subset": subset}, lazy=lazy_loader
+            {"uri": uri, "database": database, "subset": subset, **metadata}, lazy=lazy_loader
         )
-
 
 def subset_trial(
     self,
@@ -403,15 +408,18 @@ def create_protocol(
 
     """
 
+    
     try:
         base_class = getattr(
             protocol_module, "Protocol" if task == "Protocol" else f"{task}Protocol"
         )
+
     except AttributeError:
         msg = (
             f"Ignoring '{database}.{task}' protocols found in {database_yml} "
             f"because '{task}' tasks are not supported yet."
         )
+        print(msg)
         return None
 
     # Collections do not define subsets, so we artificially create one (called "files")
@@ -426,6 +434,14 @@ def create_protocol(
     #        uri: /path/to/collection.lst
     if task == "Collection":
         protocol_entries = {"files": protocol_entries}
+
+    metadata = dict()
+    # check whether base_class is a subclass of SegmentationProtocol
+    if issubclass(base_class, SegmentationProtocol):
+        metadata["classes"] = protocol_entries.pop("classes", None)
+
+    if issubclass(base_class, SpeakerDiarizationProtocol):
+        metadata["scope"] = protocol_entries.pop("scope", "file")
 
     methods = dict()
     for subset, subset_entries in protocol_entries.items():
@@ -458,6 +474,7 @@ def create_protocol(
                 database_yml,
             )
         else:
+
             methods[method_name] = functools.partialmethod(
                 subset_iter,
                 database=database,
@@ -466,7 +483,9 @@ def create_protocol(
                 subset=subset,
                 entries=subset_entries,
                 database_yml=database_yml,
+                **metadata,
             )
+
             if "trial" in subset_entries.keys():
                 methods[f"{subset}_trial"] = functools.partialmethod(
                     subset_trial,

--- a/pyannote/database/protocol/__init__.py
+++ b/pyannote/database/protocol/__init__.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2016-2020 CNRS
+# Copyright (c) 2016- CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,7 @@
 
 from .protocol import Protocol
 from .collection import CollectionProtocol
+from .segmentation import SegmentationProtocol
 from .speaker_diarization import SpeakerDiarizationProtocol
 from .speaker_spotting import SpeakerSpottingProtocol
 from .speaker_verification import SpeakerVerificationProtocol
@@ -38,9 +39,11 @@ from .speaker_recognition import SpeakerRecognitionProtocol
 __all__ = [
     "Protocol",
     "CollectionProtocol",
+    "SegmentationProtocol",
     "SpeakerDiarizationProtocol",
     "SpeakerVerificationProtocol",
     "SpeakerSpottingProtocol",
     "SpeakerIdentificationProtocol",
     "SpeakerRecognitionProtocol",
 ]
+

--- a/pyannote/database/protocol/protocol.py
+++ b/pyannote/database/protocol/protocol.py
@@ -46,6 +46,7 @@ except ImportError:
 
 Subset = Literal["train", "development", "test"]
 LEGACY_SUBSET_MAPPING = {"train": "trn", "development": "dev", "test": "tst"}
+Scope = Literal["file", "database", "global"]
 
 Preprocessor = Callable[["ProtocolFile"], Any]
 Preprocessors = Dict[Text, Preprocessor]
@@ -248,7 +249,7 @@ class Protocol:
     a development subset, and a test subset.
 
     An experimental protocol can be defined programmatically by creating a
-    class that inherits from SpeakerDiarizationProtocol and implements at least
+    class that inherits from Protocol and implements at least
     one of `train_iter`, `development_iter` and `test_iter` methods:
 
         >>> class MyProtocol(Protocol):

--- a/pyannote/database/protocol/segmentation.py
+++ b/pyannote/database/protocol/segmentation.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+# The MIT License (MIT)
+
+# Copyright (c) 2016- CNRS
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# AUTHORS
+# Hervé BREDIN - http://herve.niderb.fr
+
+
+from typing import Dict, Optional
+from .protocol import Protocol
+from .protocol import ProtocolFile
+from .protocol import Subset
+from .protocol import Preprocessor
+from .protocol import Preprocessors
+from pyannote.core import Annotation
+from pyannote.core import Timeline
+from pyannote.core import Segment
+import functools
+
+
+def crop_annotated(
+    current_file: ProtocolFile, existing_preprocessor: Optional[Preprocessor] = None
+) -> Timeline:
+    """Preprocessor that crops 'annotated' according to 'duration'
+
+    Returns 'annotated' unchanged if 'duration' is not available
+
+    Parameters
+    ----------
+    current_file : ProtocolFile
+        Protocol file.
+    existing_preprocessor : Preprocessor, optional
+        When provided, this preprocessor must be used to get the initial
+        'annotated' instead of getting it from 'current_file["annotated"]'
+
+    Returns
+    -------
+    cropped_annotated : Timeline
+        "annotated" cropped by "duration".
+    """
+
+    if existing_preprocessor is None:
+        annotated = current_file.get("annotated", None)
+    else:
+        annotated = existing_preprocessor(current_file)
+
+    if annotated is None:
+        return None
+
+    duration = current_file.get("duration", None)
+    if duration is None:
+        return annotated
+
+    # crop 'annotated' to 'duration'
+    duration = Segment(0.0, duration)
+
+    if annotated and not annotated.extent() in duration:
+        return annotated.crop(duration, mode="intersection")
+
+    return annotated
+
+
+def crop_annotation(
+    current_file: ProtocolFile, existing_preprocessor: Optional[Preprocessor] = None
+) -> Annotation:
+    """Preprocessor that crops 'annotation' by 'annotated'
+
+    Returns 'annotation' unchanged if 'annotated' is not available
+
+    Parameters
+    ----------
+    current_file : ProtocolFile
+        Protocol file.
+    existing_preprocessor : Preprocessor, optional
+        When provided, this preprocessor must be used to get the initial
+        'annotation' instead of getting it from 'current_file["annotation"]'
+
+    Returns
+    -------
+    cropped_annotation : Annotation
+        "annotation" cropped by "annotated".
+    """
+
+    if existing_preprocessor is None:
+        annotation = current_file.get("annotation", None)
+    else:
+        annotation = existing_preprocessor(current_file)
+
+    if annotation is None:
+        return None
+
+    annotated = current_file.get("annotated", None)
+    if annotated is None:
+        return annotation
+
+    # crop 'annotation' to 'annotated' extent
+    if annotated and not annotated.covers(annotation.get_timeline()):
+        return annotation.crop(annotated, mode="intersection")
+
+    return annotation
+
+
+class SegmentationProtocol(Protocol):
+    """A protocol for segmentation experiments
+
+    A segmentation protocol can be defined programmatically by creating
+    a class that inherits from SegmentationProtocol and implements at
+    least one of `train_iter`, `development_iter` and `test_iter` methods:
+
+        >>> class MySegmentationProtocol(SegmentationProtocol):
+        ...     def train_iter(self) -> Iterator[Dict]:
+        ...         yield {"uri": "filename1",
+        ...                "annotation": Annotation(...),
+        ...                "annotated": Timeline(...)}
+        ...         yield {"uri": "filename2",
+        ...                "annotation": Annotation(...),
+        ...                "annotated": Timeline(...)}
+
+    `{subset}_iter` should return an iterator of dictionnaries with
+        - "uri" key (mandatory) that provides a unique file identifier (usually
+          the filename),
+        - "annotation" key (mandatory for train and development subsets) that
+          provides reference segmentation as a `pyannote.core.Annotation`
+          instance,
+        - "annotated" key (recommended) that describes which part of the file
+          has been annotated, as a `pyannote.core.Timeline` instance. Any part
+          of "annotation" that lives outside of the provided "annotated" will
+          be removed. This is also used by `pyannote.metrics` to remove
+          un-annotated regions from its evaluation report, and by
+          `pyannote.audio` to not consider empty un-annotated regions as
+          non-speech.
+        - any other key that the protocol may provide.
+
+    It can then be used in Python like this:
+
+        >>> protocol = MySegmentationProtocol()
+        >>> for file in protocol.train():
+        ...    print(file["uri"])
+        filename1
+        filename2
+
+    A segmentation protocol can also be defined using `pyannote.database`
+    configuration file, whose (configurable) path defaults to "~/database.yml".
+
+    ~~~ Content of ~/database.yml ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Protocols:
+      MyDatabase:
+        Segmentation:
+          MyProtocol:
+            train:
+                uri: /path/to/collection.lst
+                annotation: /path/to/reference.rttm
+                annotated: /path/to/reference.uem
+                any_other_key: ... # see custom loader documentation
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    where "/path/to/collection.lst" contains the list of identifiers of the
+    files in the collection:
+
+    ~~~ Content of "/path/to/collection.lst ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    filename1
+    filename2
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    "/path/to/reference.rttm" contains the reference segmentation using
+    RTTM format:
+
+    ~~~ Content of "/path/to/reference.rttm ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    SPEAKER filename1 1 3.168 0.800 <NA> <NA> music <NA> <NA>
+    SPEAKER filename1 1 5.463 0.640 <NA> <NA> music <NA> <NA>
+    SPEAKER filename1 1 5.496 0.574 <NA> <NA> speech <NA> <NA>
+    SPEAKER filename1 1 10.454 0.499 <NA> <NA> speech <NA> <NA>
+    SPEAKER filename2 1 2.977 0.391 <NA> <NA> noise <NA> <NA>
+    SPEAKER filename2 1 18.705 0.964 <NA> <NA> noise <NA> <NA>
+    SPEAKER filename2 1 22.269 0.457 <NA> <NA> music <NA> <NA>
+    SPEAKER filename2 1 28.474 1.526 <NA> <NA> music <NA> <NA>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    "/path/to/reference.uem" describes the annotated regions using UEM format:
+
+    ~~~ Content of "/path/to/reference.uem ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    filename1 NA 0.000 30.000
+    filename2 NA 0.000 30.000
+    filename2 NA 40.000 70.000
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    It can then be used in Python like this:
+
+        >>> from pyannote.database import registry
+        >>> protocol = registry.get_protocol('MyDatabase.SpeakerDiarization.MyProtocol')
+        >>> for file in protocol.train():
+        ...    print(file["uri"])
+        filename1
+        filename2
+    """
+
+    def __init__(self, preprocessors: Optional[Preprocessors] = None):
+
+        if preprocessors is None:
+            preprocessors = dict()
+
+        # wrap exisiting "annotated" preprocessor by crop_annotated so that
+        # "annotated" is automatically cropped by file "duration" when provided
+        preprocessors["annotated"] = functools.partial(
+            crop_annotated, existing_preprocessor=preprocessors.get("annotated", None)
+        )
+
+        # wrap exisiting "annotation" preprocessor by crop_annotation so that
+        # "annotation" is automatically cropped by "annotated" when provided
+        preprocessors["annotation"] = functools.partial(
+            crop_annotation, existing_preprocessor=preprocessors.get("annotation", None)
+        )
+
+        super().__init__(preprocessors=preprocessors)
+
+    def stats(self, subset: Subset = "train") -> Dict:
+        """Obtain global statistics on a given subset
+
+        Parameters
+        ----------
+        subset : {'train', 'development', 'test'}
+
+        Returns
+        -------
+        stats : dict
+            Dictionary with the followings keys:
+            * annotated: float
+            total duration (in seconds) of the parts that were manually annotated
+            * annotation: float
+            total duration (in seconds) of actual annotations
+            * n_files: int
+            number of files in the subset
+            * labels: dict
+            maps classes with their total duration (in seconds)
+        """
+
+        from ..util import get_annotated
+
+        annotated_duration = 0.0
+        annotation_duration = 0.0
+        n_files = 0
+        labels = {}
+
+        for item in getattr(self, subset)():
+
+            annotated = get_annotated(item)
+            annotated_duration += annotated.duration()
+
+            # increment 'annotation' total duration
+            annotation = item["annotation"]
+            annotation_duration += annotation.get_timeline().duration()
+
+            for label, duration in annotation.chart():
+                if label not in labels:
+                    labels[label] = 0.0
+                labels[label] += duration
+            n_files += 1
+
+        stats = {
+            "annotated": annotated_duration,
+            "annotation": annotation_duration,
+            "n_files": n_files,
+            "labels": labels,
+        }
+
+        return stats


### PR DESCRIPTION
* Segmentation protocols support an optional "classes" key that contains the list of classes (e.g. speech/noise/music) they contain.
* Speaker diarization protocols now inherit from segmentation protocols.
* Speaker diarization protocols now support an optional "scope" key indicating the scope of speaker labels (file, database, or global).