### PR TITLE
replace `delim_whitespace=True` by `sep="\s+"`

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 #########
 
+develop
+~~~~~~~~
+
+ - chore: remove deprecated use of `delim_whitespace`
+
 Version 5.1.0 (2024-04-05)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pyannote/database/loader.py
+++ b/pyannote/database/loader.py
@@ -90,7 +90,7 @@ def load_trial(file_trial):
     """
 
     trials = pd.read_table(
-        file_trial, delim_whitespace=True, names=["reference", "uri1", "uri2"]
+        file_trial, sep="\s+", names=["reference", "uri1", "uri2"]
     )
 
     for _, reference, uri1, uri2 in trials.itertuples():
@@ -289,7 +289,7 @@ class CTMLoader:
             "confidence": float,
         }
         self.data_ = pd.read_csv(
-            ctm, names=names, dtype=dtype, delim_whitespace=True
+            ctm, names=names, dtype=dtype, sep="\s+"
         ).groupby("uri")
 
     def __call__(self, current_file: ProtocolFile) -> Union["Doc", None]:
@@ -354,7 +354,7 @@ class MAPLoader:
             "uri": str,
         }
         self.data_ = pd.read_csv(
-            mapping, names=names, dtype=dtype, delim_whitespace=True
+            mapping, names=names, dtype=dtype, sep="\s+"
         )
 
         # get colum 'value' dtype, allowing us to acces it during subset

--- a/pyannote/database/util.py
+++ b/pyannote/database/util.py
@@ -179,7 +179,7 @@ def load_rttm(file_rttm, keep_type="SPEAKER"):
         file_rttm,
         names=names,
         dtype=dtype,
-        delim_whitespace=True,
+        sep="\s+",
         keep_default_na=True,
     )
 
@@ -213,7 +213,7 @@ def load_stm(file_stm):
     dtype = {"uri": str, "speaker": str, "start": float, "end": float}
     data = pd.read_csv(
         file_stm,
-        delim_whitespace=True,
+        sep="\s+",
         usecols=[0, 2, 3, 4],
         dtype=dtype,
         names=list(dtype),
@@ -250,7 +250,7 @@ def load_mdtm(file_mdtm):
         file_mdtm,
         names=names,
         dtype=dtype,
-        delim_whitespace=True,
+        sep="\s+",
         keep_default_na=False,
     )
 
@@ -281,7 +281,7 @@ def load_uem(file_uem):
 
     names = ["uri", "NA1", "start", "end"]
     dtype = {"uri": str, "start": float, "end": float}
-    data = pd.read_csv(file_uem, names=names, dtype=dtype, delim_whitespace=True)
+    data = pd.read_csv(file_uem, names=names, dtype=dtype, sep="\s+")
 
     timelines = dict()
     for uri, parts in data.groupby("uri"):
@@ -306,7 +306,7 @@ def load_lab(path, uri: str = None) -> Annotation:
 
     names = ["start", "end", "label"]
     dtype = {"start": float, "end": float, "label": str}
-    data = pd.read_csv(path, names=names, dtype=dtype, delim_whitespace=True)
+    data = pd.read_csv(path, names=names, dtype=dtype, sep="\s+")
 
     annotation = Annotation(uri=uri)
     for i, turn in data.iterrows():


### PR DESCRIPTION
The `delim_whitespace` keyword in `pd.read_csv` is deprecated and will be removed in a future version. Use ``sep='\s+'`` instead