### PR TITLE
fix: update entry point selection for loaders for py 3.9 compatibility

### DIFF
--- a/pyannote/database/custom.py
+++ b/pyannote/database/custom.py
@@ -67,10 +67,18 @@ from .util import get_annotated
 from .loader import load_lst, load_trial
 
 # All "Loader" classes types (eg RTTMLoader, UEMLoader, ...) retrieved from the entry point.
-LOADERS = {
-    ep.name: ep
-    for ep in entry_points(group="pyannote.database.loader")
-}
+try:
+    # Python >= 3.10 style
+    LOADERS = {
+        ep.name: ep
+        for ep in entry_points(group="pyannote.database.loader")
+    }
+except TypeError:
+    # Python < 3.10 style
+    LOADERS = {
+        ep.name: ep
+        for ep in entry_points().get("pyannote.database.loader", [])
+    }
 
 
 def Template(template: Text, database_yml: Path) -> Callable[[ProtocolFile], Any]:


### PR DESCRIPTION
closes #105 