### PR TITLE
Load RTTMs with `keep_default_na=False` to avoid `nan` speaker label

### DIFF
--- a/src/pyannote/database/util.py
+++ b/src/pyannote/database/util.py
@@ -180,7 +180,7 @@ def load_rttm(file_rttm, keep_type="SPEAKER"):
         names=names,
         dtype=dtype,
         sep=r"\s+",
-        keep_default_na=True,
+        keep_default_na=False,
     )
 
     annotations = dict()

--- a/src/pyannote/database/util.py
+++ b/src/pyannote/database/util.py
@@ -175,24 +175,25 @@ def load_rttm(file_rttm, keep_type="SPEAKER"):
         "NA6",
     ]
     dtype = {"uri": str, "start": float, "duration": float, "speaker": str}
-    na_values = {n: ["<NA>"] for n in names if dtype.get(n) is not str}
     data = pd.read_csv(
         file_rttm,
         names=names,
         dtype=dtype,
         sep=r"\s+",
-        na_values=na_values,
+        na_values=["<NA>"],
         keep_default_na=False,
     )
 
     annotations = dict()
     for uri, turns in data.groupby("uri"):
+        if pd.isna(uri):
+            uri = None
         annotation = Annotation(uri=uri)
         for i, turn in turns.iterrows():
             if turn.type != keep_type:
                 continue
             segment = Segment(turn.start, turn.start + turn.duration)
-            annotation[segment, i] = turn.speaker
+            annotation[segment, i] = turn.speaker if not pd.isna(turn.speaker) else None
         annotations[uri] = annotation
 
     return annotations

--- a/src/pyannote/database/util.py
+++ b/src/pyannote/database/util.py
@@ -175,11 +175,13 @@ def load_rttm(file_rttm, keep_type="SPEAKER"):
         "NA6",
     ]
     dtype = {"uri": str, "start": float, "duration": float, "speaker": str}
+    na_values = {n: ["<NA>"] for n in names if dtype.get(n) is not str}
     data = pd.read_csv(
         file_rttm,
         names=names,
         dtype=dtype,
         sep=r"\s+",
+        na_values=na_values,
         keep_default_na=False,
     )
 


### PR DESCRIPTION
Currently, `load_rttm` uses `pd.read_csv()` with `keep_default_na=True`. This results in speaker labels such as "&lt;NA&gt;", "nan", "NA", "N/A", and "NULL" all being parsed as the float `nan` value.

It appears that the only value that could legitimately represent a NaN/missing value in an RTTM file is `<NA>`, but it seems that it would be unexpected for most (meaningful) columns, and it definitely seems incorrect to read it as a float for string columns (`uri`, `speaker`).

The fix I'm proposing is therefore to pass `keep_default_na=False` and `na_values=["<NA>"]`, and convert `nan` values to `None` for `uri` and `speaker`.