### PR TITLE
PYA-1783: Add multichannel support

### DIFF
--- a/src/pyannote/database/loader.py
+++ b/src/pyannote/database/loader.py
@@ -103,12 +103,6 @@ class RTTMLoader:
     path : str
         Path to RTTM file with optional ProtocolFile key placeholders
         (e.g. "/path/to/{database}/{subset}/{uri}.rttm")
-
-    Notes
-    -----
-    When the `ProtocolFile` provides a `channel` key, only the annotation of
-    that (1-based) channel is returned. Otherwise every channel is merged into
-    a single `Annotation` (backward-compatible behavior).
     """
 
     def __init__(self, path: Text = None):
@@ -133,6 +127,8 @@ class RTTMLoader:
         if len(by_channel) == 1:
             return next(iter(by_channel.values()))
 
+        # if there are multiple channels but I don't care about channels, merge them all
+        # into a single Annotation (this is the historical behavior of load_rttm)
         merged = Annotation(uri=uri)
         for channel in sorted(by_channel):
             for segment, track, label in by_channel[channel].itertracks(yield_label=True):

--- a/src/pyannote/database/loader.py
+++ b/src/pyannote/database/loader.py
@@ -103,6 +103,12 @@ class RTTMLoader:
     path : str
         Path to RTTM file with optional ProtocolFile key placeholders
         (e.g. "/path/to/{database}/{subset}/{uri}.rttm")
+
+    Notes
+    -----
+    When the `ProtocolFile` provides a `channel` key, only the annotation of
+    that (1-based) channel is returned. Otherwise every channel is merged into
+    a single `Annotation` (backward-compatible behavior).
     """
 
     def __init__(self, path: Text = None):
@@ -112,29 +118,51 @@ class RTTMLoader:
 
         _, placeholders, _, _ = zip(*string.Formatter().parse(self.path))
         self.placeholders_ = set(placeholders) - set([None])
-        self.loaded_ = dict() if self.placeholders_ else load_rttm(self.path)
+        # {uri: {channel: Annotation}} ; channels are merged on demand (see _select)
+        self.loaded_ = (
+            dict() if self.placeholders_ else load_rttm(self.path, keep_channel=True)
+        )
+
+    @staticmethod
+    def _select(by_channel: dict, uri: Text, channel: int = None) -> Annotation:
+        """Annotation of `channel`, or all channels merged when `channel` is None."""
+        if channel is not None:
+            return by_channel.get(channel, Annotation(uri=uri))
+
+        # channel-agnostic: reproduce the historical single-Annotation behavior
+        if len(by_channel) == 1:
+            return next(iter(by_channel.values()))
+
+        merged = Annotation(uri=uri)
+        for channel in sorted(by_channel):
+            for segment, track, label in by_channel[channel].itertracks(yield_label=True):
+                merged[segment, track] = label
+        return merged
 
     def __call__(self, file: ProtocolFile) -> Annotation:
         uri = file["uri"]
+        channel = file.get("channel", None)
+        if channel is not None:
+            channel = int(channel)
 
         if uri in self.loaded_:
-            return self.loaded_[uri]
+            return self._select(self.loaded_[uri], uri, channel)
 
         sub_file = {key: file[key] for key in self.placeholders_}
-        loaded = load_rttm(self.path.format(**sub_file))
+        loaded = load_rttm(self.path.format(**sub_file), keep_channel=True)
         if uri not in loaded:
-            loaded[uri] = Annotation(uri=uri)
+            loaded[uri] = dict()
 
         # do not cache annotations when there is one RTTM file per "uri"
         # since loading it should be quite fast
         if "uri" in self.placeholders_:
-            return loaded[uri]
+            return self._select(loaded[uri], uri, channel)
 
         # when there is more than one file in loaded RTTM, cache them all
         # so that loading future "uri" will be instantaneous
         self.loaded_.update(loaded)
 
-        return self.loaded_[uri]
+        return self._select(self.loaded_[uri], uri, channel)
 
 
 class STMLoader:

--- a/src/pyannote/database/util.py
+++ b/src/pyannote/database/util.py
@@ -167,7 +167,7 @@ def load_rttm(file_rttm, keep_type="SPEAKER", keep_channel=False):
         {uri: pyannote.core.Annotation} dictionary.
         When `keep_channel` is True, a nested
         {uri: {channel: pyannote.core.Annotation}} dictionary, where `channel`
-        is the (1-based) integer channel read from the RTTM file.
+        is the integer channel read from the RTTM file (starting at 1).
     """
 
     names = [

--- a/src/pyannote/database/util.py
+++ b/src/pyannote/database/util.py
@@ -145,7 +145,7 @@ def get_label_identifier(label, current_file):
     return database + "|" + label
 
 
-def load_rttm(file_rttm, keep_type="SPEAKER"):
+def load_rttm(file_rttm, keep_type="SPEAKER", keep_channel=False):
     """Load RTTM file
 
     Parameter
@@ -155,17 +155,25 @@ def load_rttm(file_rttm, keep_type="SPEAKER"):
     keep_type : str, optional
         Only keep lines with this type (field #1 in RTTM specs).
         Defaults to "SPEAKER".
+    keep_channel : bool, optional
+        Return one `Annotation` per (uri, channel) instead of merging every
+        channel (field #3 in RTTM specs) into a single `Annotation`.
+        Defaults to False (channels merged, backward-compatible behavior).
 
     Returns
     -------
     annotations : `dict`
-        Speaker diarization as a {uri: pyannote.core.Annotation} dictionary.
+        When `keep_channel` is False (default), speaker diarization as a
+        {uri: pyannote.core.Annotation} dictionary.
+        When `keep_channel` is True, a nested
+        {uri: {channel: pyannote.core.Annotation}} dictionary, where `channel`
+        is the (1-based) integer channel read from the RTTM file.
     """
 
     names = [
         "type",
         "uri",
-        "NA2",
+        "channel",
         "start",
         "duration",
         "NA3",
@@ -183,15 +191,24 @@ def load_rttm(file_rttm, keep_type="SPEAKER"):
         keep_default_na=True,
     )
 
-    annotations = dict()
-    for uri, turns in data.groupby("uri"):
+    def _annotation(uri, turns):
         annotation = Annotation(uri=uri)
         for i, turn in turns.iterrows():
             if turn.type != keep_type:
                 continue
             segment = Segment(turn.start, turn.start + turn.duration)
             annotation[segment, i] = turn.speaker
-        annotations[uri] = annotation
+        return annotation
+
+    if keep_channel:
+        annotations = dict()
+        for (uri, channel), turns in data.groupby(["uri", "channel"]):
+            annotations.setdefault(uri, dict())[int(channel)] = _annotation(uri, turns)
+        return annotations
+
+    annotations = dict()
+    for uri, turns in data.groupby("uri"):
+        annotations[uri] = _annotation(uri, turns)
 
     return annotations
 

--- a/tests/data/rttms/multichannel.rttm
+++ b/tests/data/rttms/multichannel.rttm
@@ -1,0 +1,4 @@
+SPEAKER conv1 1 0.000 2.000 <NA> <NA> speaker_A <NA> <NA>
+SPEAKER conv1 2 1.500 1.000 <NA> <NA> speaker_B <NA> <NA>
+SPEAKER conv1 1 3.000 1.000 <NA> <NA> speaker_A <NA> <NA>
+SPEAKER conv2 1 0.000 1.000 <NA> <NA> speaker_C <NA> <NA>

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+# The MIT License (MIT)
+
+# Copyright (c) 2025- pyannoteAI
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+
+"""Tests for multichannel-aware RTTM loading (load_rttm + RTTMLoader)."""
+
+from pathlib import Path
+
+from pyannote.core import Annotation
+from pyannote.database.loader import RTTMLoader
+from pyannote.database.protocol.protocol import ProtocolFile
+from pyannote.database.util import load_rttm
+
+RTTMS = Path(__file__).parent / "data" / "rttms"
+SINGLE = str(RTTMS / "train.rttm")          # single-channel: filename1 / filename2 on channel 1
+MULTI = str(RTTMS / "multichannel.rttm")    # conv1: ch1=speaker_A (x2), ch2=speaker_B ; conv2: ch1=speaker_C
+
+
+def n_segments(annotation: Annotation) -> int:
+    return len(list(annotation.itertracks()))
+
+
+# --------------------------------------------------------------------------- #
+# load_rttm — backward compatibility (keep_channel=False, the default)
+# --------------------------------------------------------------------------- #
+
+def test_load_rttm_default_shape_unchanged():
+    annotations = load_rttm(SINGLE)
+    assert set(annotations) == {"filename1", "filename2"}
+    assert isinstance(annotations["filename1"], Annotation)
+    assert annotations["filename1"].labels() == ["speaker_A"]
+    assert annotations["filename2"].labels() == ["speaker_B"]
+
+
+def test_load_rttm_default_merges_channels():
+    # without keep_channel, all channels of a uri collapse into one Annotation
+    annotations = load_rttm(MULTI)
+    assert set(annotations) == {"conv1", "conv2"}
+    assert isinstance(annotations["conv1"], Annotation)
+    assert set(annotations["conv1"].labels()) == {"speaker_A", "speaker_B"}
+    assert n_segments(annotations["conv1"]) == 3  # A, B, A
+
+
+# --------------------------------------------------------------------------- #
+# load_rttm — keep_channel=True
+# --------------------------------------------------------------------------- #
+
+def test_load_rttm_keep_channel_shape():
+    annotations = load_rttm(MULTI, keep_channel=True)
+    # {uri: {channel: Annotation}}
+    assert set(annotations) == {"conv1", "conv2"}
+    assert set(annotations["conv1"]) == {1, 2}
+    assert set(annotations["conv2"]) == {1}
+    assert all(isinstance(channel, int) for channel in annotations["conv1"])
+    assert isinstance(annotations["conv1"][1], Annotation)
+
+
+def test_load_rttm_keep_channel_content():
+    annotations = load_rttm(MULTI, keep_channel=True)
+    assert annotations["conv1"][1].labels() == ["speaker_A"]
+    assert annotations["conv1"][2].labels() == ["speaker_B"]
+    assert n_segments(annotations["conv1"][1]) == 2  # two speaker_A turns on channel 1
+    assert n_segments(annotations["conv1"][2]) == 1
+    assert annotations["conv2"][1].labels() == ["speaker_C"]
+
+
+def test_load_rttm_keep_channel_single_channel_file():
+    # an ordinary single-channel file is simply nested under channel 1
+    annotations = load_rttm(SINGLE, keep_channel=True)
+    assert set(annotations["filename1"]) == {1}
+    assert annotations["filename1"][1].labels() == ["speaker_A"]
+
+
+# --------------------------------------------------------------------------- #
+# RTTMLoader — channel-aware preprocessor
+# --------------------------------------------------------------------------- #
+
+def test_rttmloader_without_channel_is_backward_compatible():
+    loader = RTTMLoader(MULTI)
+    annotation = loader(ProtocolFile({"uri": "conv1"}))
+    assert isinstance(annotation, Annotation)
+    assert set(annotation.labels()) == {"speaker_A", "speaker_B"}
+    assert n_segments(annotation) == 3
+
+
+def test_rttmloader_selects_requested_channel():
+    loader = RTTMLoader(MULTI)
+    channel1 = loader(ProtocolFile({"uri": "conv1", "channel": 1}))
+    channel2 = loader(ProtocolFile({"uri": "conv1", "channel": 2}))
+    assert channel1.labels() == ["speaker_A"]
+    assert channel2.labels() == ["speaker_B"]
+
+
+def test_rttmloader_missing_channel_returns_empty_annotation():
+    loader = RTTMLoader(MULTI)
+    # conv2 has only channel 1 -> asking for channel 2 yields an empty Annotation
+    annotation = loader(ProtocolFile({"uri": "conv2", "channel": 2}))
+    assert isinstance(annotation, Annotation)
+    assert n_segments(annotation) == 0
+
+
+def test_rttmloader_unknown_uri_returns_empty_annotation():
+    loader = RTTMLoader(MULTI)
+    annotation = loader(ProtocolFile({"uri": "does_not_exist"}))
+    assert isinstance(annotation, Annotation)
+    assert n_segments(annotation) == 0
+
+
+def test_rttmloader_single_channel_no_channel_equals_channel_one():
+    # for a plain single-channel file, the channel-agnostic result must match channel 1
+    loader = RTTMLoader(SINGLE)
+    merged = loader(ProtocolFile({"uri": "filename1"}))
+    channel1 = loader(ProtocolFile({"uri": "filename1", "channel": 1}))
+    assert merged == channel1
+
+
+def test_rttmloader_accepts_string_channel():
+    # channel coming from a mapping file may be a numeric string
+    loader = RTTMLoader(MULTI)
+    annotation = loader(ProtocolFile({"uri": "conv1", "channel": "2"}))
+    assert annotation.labels() == ["speaker_B"]
+
+
+def test_rttmloader_resolves_lazy_channel():
+    # mimics a protocol: both 'channel' and 'annotation' are lazy keys, and
+    # resolving 'annotation' must pull the lazily-computed 'channel' (as a
+    # `channel:` entry in database.yml would, via gather_loaders).
+    lazy = {"channel": lambda f: 2, "annotation": RTTMLoader(MULTI)}
+    file = ProtocolFile({"uri": "conv1"}, lazy=lazy)
+    assert file["annotation"].labels() == ["speaker_B"]

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2025- pyannoteAI
+# Copyright (c) 2026- pyannoteAI
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Optional multichannel support in RTTM loading

### What
The RTTM **channel** field (column #3) was parsed but discarded. This adds an **opt-in** way to keep it, so a multichannel recording (telephone, per-headset,source-separated) can expose one reference `Annotation` per channel.

### API
- `load_rttm(path, keep_channel=True)` → nested `{uri: {channel: Annotation}}`. Default `keep_channel=False` is unchanged.
- `RTTMLoader` returns the annotation of `file["channel"]` when the ProtocolFile provides one; otherwise it merges all channels (previous behavior).

### Key example
Given this RTTM (column #3 is the channel):
```
SPEAKER conv1 1 0.0 2.0 <NA> <NA> speaker_A <NA> <NA>
SPEAKER conv1 2 1.5 1.0 <NA> <NA> speaker_B <NA> <NA>
SPEAKER conv2 1 0.0 1.0 <NA> <NA> speaker_C <NA> <NA>
```

**Without `keep_channel` (default — unchanged):** all channels merge into one Annotation.
```python
>>> load_rttm("conv.rttm")
{'conv1': <Annotation>, 'conv2': <Annotation>}
>>> load_rttm("conv.rttm")['conv1'].labels()
['speaker_A', 'speaker_B']        # channels 1 and 2 merged
```

**With `keep_channel=True` — one Annotation per channel:**
```python
>>> load_rttm("conv.rttm", keep_channel=True)
{'conv1': {1: <Annotation>, 2: <Annotation>}, 'conv2': {1: <Annotation>}}
>>> load_rttm("conv.rttm", keep_channel=True)['conv1'][2].labels()
['speaker_B']                     # just channel 2
```

At the protocol level, the same distinction is driven by a `channel` key on the file:
```python
RTTMLoader("conv.rttm")({"uri": "conv1"})               # -> merged (speaker_A + speaker_B)
RTTMLoader("conv.rttm")({"uri": "conv1", "channel": 2}) # -> speaker_B only
```

### Tests
`tests/test_loader.py` (+ a multichannel fixture) covers the default/merged path, the `keep_channel` shape and content, `RTTMLoader` channel selection and its backward-compatible default, and lazy `channel` resolution through `ProtocolFile`. `uv run pytest tests` is green.